### PR TITLE
Fixed formatting issue causing a dead link

### DIFF
--- a/content/gsoc-2019/project-ideas-collection/reward-and-delight/contents.lr
+++ b/content/gsoc-2019/project-ideas-collection/reward-and-delight/contents.lr
@@ -10,7 +10,7 @@ Prototype a small, fun idea that gives reward and delight to users, e.g. a graph
 ---
 rationale: 
 
-Addresses all the [insights from our user research]((https://medium.com/@janepk/findings-from-the-discovery-phase-of-cc-usability-3bde89d55a74)).
+Addresses all the [insights from our user research](https://medium.com/@janepk/findings-from-the-discovery-phase-of-cc-usability-3bde89d55a74).
 ---
 resources:
 


### PR DESCRIPTION
Due to incorrect markdown formatting (extra parentheses), the hyperlink to the "insights from our research" URL is leading to a dead link--see: http://creativecommons.github.io/gsoc-2019/project-ideas/all/#reward

I've removed the extra parentheses